### PR TITLE
shared-utilities Add SharedUtilities Folder and Project

### DIFF
--- a/AdventOfCode2025/AdventOfCode2025.slnx
+++ b/AdventOfCode2025/AdventOfCode2025.slnx
@@ -1,6 +1,12 @@
 <Solution>
+  <Folder Name="/PuzzleSolutions/">
   <Project Path="Day1/Day1.csproj" />
   <Project Path="Day2/Day2.csproj" Id="6ee23127-0e41-48fb-9881-25f5aa196087" />
   <Project Path="Day4/Day4.csproj" Id="ef2160fe-a2af-476e-8900-1a61574a4098" />
   <Project Path="Day5/Day5.csproj" Id="28036fd9-ace6-4661-8d0e-304ed786d4cd" />
+  </Folder>
+  <Folder Name="/Shared/">
+    <Project Path="SharedUtilities.Test/SharedUtilities.Test.csproj" Id="a1ef0cd8-6cf5-4cc7-be7f-3ad5b066e984" />
+    <Project Path="SharedUtilities/SharedUtilities.csproj" Id="dc409f31-00f5-46e3-87a7-c5e9dc320731" />
+  </Folder>
 </Solution>

--- a/AdventOfCode2025/Day4/Day4.csproj
+++ b/AdventOfCode2025/Day4/Day4.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SharedUtilities\SharedUtilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="NUnit.Framework" />
   </ItemGroup>
 

--- a/AdventOfCode2025/Day4/Part1/WhenAGridOfPaperRollLocationsIsPassedIn.cs
+++ b/AdventOfCode2025/Day4/Part1/WhenAGridOfPaperRollLocationsIsPassedIn.cs
@@ -1,3 +1,5 @@
+using SharedUtilities;
+
 namespace Day4.Part1 {
     public class WhenAGridOfPaperRollLocationsIsPassedIn {
         private int result;

--- a/AdventOfCode2025/Day4/Part2/WhenAGridOfPaperRollLocationsIsPassedIn.cs
+++ b/AdventOfCode2025/Day4/Part2/WhenAGridOfPaperRollLocationsIsPassedIn.cs
@@ -1,3 +1,5 @@
+using SharedUtilities;
+
 namespace Day4.Part2 {
     public class WhenAGridOfPaperRollLocationsIsPassedIn {
         private int result;

--- a/AdventOfCode2025/Day4/Program.cs
+++ b/AdventOfCode2025/Day4/Program.cs
@@ -1,6 +1,6 @@
-﻿using Day4;
-using Day4.Part1;
+﻿using Day4.Part1;
 using Day4.Part2;
+using SharedUtilities;
 
 var file = "puzzleInput.txt";
 

--- a/AdventOfCode2025/Day5/Day5.csproj
+++ b/AdventOfCode2025/Day5/Day5.csproj
@@ -10,10 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AdventOfCode2025/SharedUtilities.Test/SharedUtilities.Test.csproj
+++ b/AdventOfCode2025/SharedUtilities.Test/SharedUtilities.Test.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharedUtilities\SharedUtilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/AdventOfCode2025/SharedUtilities.Test/SharedUtilities.Test.csproj
+++ b/AdventOfCode2025/SharedUtilities.Test/SharedUtilities.Test.csproj
@@ -10,10 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringArrayIsPassedIn.cs
+++ b/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringArrayIsPassedIn.cs
@@ -112,7 +112,7 @@ namespace SharedUtilities.Test.UsingTheTwoDArrayConverter {
         public void ThenItThrowsOnNullElementInArray() {
             var gridRows = new[] { "ABC", null, "DEF" };
 
-            Assert.Throws<NullReferenceException>(() => TwoDArrayConverter.ConvertTo2DArray(gridRows));
+            Assert.Throws<ArgumentException>(() => TwoDArrayConverter.ConvertTo2DArray(gridRows));
         }
     }
 }

--- a/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringArrayIsPassedIn.cs
+++ b/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringArrayIsPassedIn.cs
@@ -1,0 +1,118 @@
+namespace SharedUtilities.Test.UsingTheTwoDArrayConverter {
+    public class WhenAStringArrayIsPassedIn {
+
+        [Test]
+        public void ThenItIsConvertedToA2DCharArray() {
+            var gridRows = new[] { "ABC", "DEF", "GHI" };
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+            Assert.That(result[2], Is.EqualTo(new[] { 'G', 'H', 'I' }));
+        }
+
+        [Test]
+        public void ThenItTrimsWhitespaceFromRows() {
+            var gridRows = new[] { "  ABC  ", "  DEF  " };
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+        }
+
+        [Test]
+        public void ThenItHandlesSingleRow() {
+            var gridRows = new[] { "ABCDE" };
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result.Length, Is.EqualTo(1));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C', 'D', 'E' }));
+        }
+
+        [Test]
+        public void ThenItHandlesUnevenRowLengths() {
+            var gridRows = new[] { "AB", "CDEF", "G" };
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'C', 'D', 'E', 'F' }));
+            Assert.That(result[2], Is.EqualTo(new[] { 'G' }));
+        }
+
+        [Test]
+        public void ThenItHandlesEmptyArray() {
+            var gridRows = new string[0];
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ThenItHandlesEmptyStringElements() {
+            var gridRows = new[] { "ABC", "", "DEF" };
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new char[0]));
+            Assert.That(result[2], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+        }
+
+        [Test]
+        public void ThenItHandlesWhitespaceOnlyElements() {
+            var gridRows = new[] { "ABC", "   ", "DEF" };
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new char[0]));
+            Assert.That(result[2], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+        }
+
+        [Test]
+        public void ThenItThrowsOnNullInput() {
+            string[] gridRows = null;
+
+            Assert.Throws<ArgumentNullException>(() => TwoDArrayConverter.ConvertTo2DArray(gridRows));
+        }
+
+        [Test]
+        public void ThenItHandlesNumericCharacters() {
+            var gridRows = new[] { "123", "456", "789" };
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { '1', '2', '3' }));
+            Assert.That(result[1], Is.EqualTo(new[] { '4', '5', '6' }));
+            Assert.That(result[2], Is.EqualTo(new[] { '7', '8', '9' }));
+        }
+
+        [Test]
+        public void ThenItHandlesSpecialCharacters() {
+            var gridRows = new[] { "!@#", "$%^" };
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { '!', '@', '#' }));
+            Assert.That(result[1], Is.EqualTo(new[] { '$', '%', '^' }));
+        }
+
+        [Test]
+        public void ThenItThrowsOnNullElementInArray() {
+            var gridRows = new[] { "ABC", null, "DEF" };
+
+            Assert.Throws<NullReferenceException>(() => TwoDArrayConverter.ConvertTo2DArray(gridRows));
+        }
+    }
+}

--- a/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedIn.cs
+++ b/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedIn.cs
@@ -1,0 +1,151 @@
+namespace SharedUtilities.Test.UsingTheTwoDArrayConverter {
+    public class WhenAStringIsPassedIn {
+
+        [Test]
+        public void ThenItIsConvertedToA2DCharArray() {
+            var grid = "ABC\nDEF\nGHI";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+            Assert.That(result[2], Is.EqualTo(new[] { 'G', 'H', 'I' }));
+        }
+
+        [Test]
+        public void ThenItHandlesCarriageReturnLineFeed() {
+            var grid = "ABC\r\nDEF";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+        }
+
+        [Test]
+        public void ThenItTrimsWhitespaceFromRows() {
+            var grid = "  ABC  \n  DEF  ";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+        }
+
+        [Test]
+        public void ThenItHandlesSingleRow() {
+            var grid = "ABCDE";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(1));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C', 'D', 'E' }));
+        }
+
+        [Test]
+        public void ThenItHandlesUnevenRowLengths() {
+            var grid = "AB\nCDEF\nG";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'C', 'D', 'E', 'F' }));
+            Assert.That(result[2], Is.EqualTo(new[] { 'G' }));
+        }
+
+        [Test]
+        public void ThenItHandlesEmptyStringInput() {
+            var grid = "";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ThenItHandlesGridWithOnlyNewlines() {
+            var grid = "\n\n\n";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ThenItHandlesExcessiveLeadingNewlines() {
+            var grid = "\n\n\nABC\nDEF";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+        }
+
+        [Test]
+        public void ThenItHandlesExcessiveTrailingNewlines() {
+            var grid = "ABC\nDEF\n\n\n";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+        }
+
+        [Test]
+        public void ThenItHandlesExcessiveLeadingAndTrailingNewlines() {
+            var grid = "\n\nABC\nDEF\n\n";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', 'B', 'C' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'D', 'E', 'F' }));
+        }
+
+        [Test]
+        public void ThenItThrowsOnNullInput() {
+            string grid = null;
+
+            Assert.Throws<ArgumentNullException>(() => TwoDArrayConverter.ConvertTo2DArray(grid));
+        }
+
+        [Test]
+        public void ThenItHandlesNumericCharacters() {
+            var grid = "123\n456\n789";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { '1', '2', '3' }));
+            Assert.That(result[1], Is.EqualTo(new[] { '4', '5', '6' }));
+            Assert.That(result[2], Is.EqualTo(new[] { '7', '8', '9' }));
+        }
+
+        [Test]
+        public void ThenItHandlesSpecialCharacters() {
+            var grid = "!@#\n$%^";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { '!', '@', '#' }));
+            Assert.That(result[1], Is.EqualTo(new[] { '$', '%', '^' }));
+        }
+
+        [Test]
+        public void ThenItHandlesMixedCharacters() {
+            var grid = "A1!\nB2@";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { 'A', '1', '!' }));
+            Assert.That(result[1], Is.EqualTo(new[] { 'B', '2', '@' }));
+        }
+    }
+}

--- a/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
+++ b/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
@@ -9,7 +9,109 @@ namespace SharedUtilities.Test.UsingTheTwoDArrayConverter {
 
         [Test]
         public void ThenItIsConvertedToA2DArray() {
-            Assert.Pass();
+            var grid = "1,2,3\n4,5,6\n7,8,9";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { "1", "2", "3" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "4", "5", "6" }));
+            Assert.That(result[2], Is.EqualTo(new[] { "7", "8", "9" }));
+        }
+
+        [Test]
+        public void ThenItHandlesMultipleCharacterSeparators() {
+            var grid = "apple||banana||cherry\ndog||elephant||fox";
+            var separator = "||";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "apple", "banana", "cherry" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "dog", "elephant", "fox" }));
+        }
+
+        [Test]
+        public void ThenItTrimsWhitespaceFromRows() {
+            var grid = "  1,2,3  \n  4,5,6  ";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result[0], Is.EqualTo(new[] { "1", "2", "3" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "4", "5", "6" }));
+        }
+
+        [Test]
+        public void ThenItHandlesCarriageReturnLineFeed() {
+            var grid = "a,b,c\r\nd,e,f";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "a", "b", "c" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "d", "e", "f" }));
+        }
+
+        [Test]
+        public void ThenItHandlesSingleRow() {
+            var grid = "1,2,3,4,5";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(1));
+            Assert.That(result[0], Is.EqualTo(new[] { "1", "2", "3", "4", "5" }));
+        }
+
+        [Test]
+        public void ThenItHandlesUnevenRowLengths() {
+            var grid = "1,2\n3,4,5,6\n7";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(3));
+            Assert.That(result[0], Is.EqualTo(new[] { "1", "2" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "3", "4", "5", "6" }));
+            Assert.That(result[2], Is.EqualTo(new[] { "7" }));
+        }
+
+        [Test]
+        public void ThenItHandlesStringArrayInput() {
+            var gridRows = new[] { "10|20|30", "40|50|60" };
+            var separator = "|";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(gridRows, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "10", "20", "30" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "40", "50", "60" }));
+        }
+
+        [Test]
+        public void ThenItRemovesEmptyEntriesFromSplit() {
+            var grid = "1,,2,3\n4,5,,6";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result[0], Is.EqualTo(new[] { "1", "2", "3" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "4", "5", "6" }));
+        }
+
+        [Test]
+        public void ThenItHandlesSpaceSeparator() {
+            var grid = "one two three\nfour five six";
+            var separator = " ";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "one", "two", "three" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "four", "five", "six" }));
         }
     }
 }

--- a/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
+++ b/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
@@ -1,6 +1,4 @@
-﻿using SharedUtilities;
-
-namespace SharedUtilities.Test.UsingTheTwoDArrayConverter {
+﻿namespace SharedUtilities.Test.UsingTheTwoDArrayConverter {
     public class WhenAStringIsPassedInWithASeparator {
 
         [SetUp]

--- a/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
+++ b/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
@@ -107,5 +107,109 @@
             Assert.That(result[0], Is.EqualTo(new[] { "one", "two", "three" }));
             Assert.That(result[1], Is.EqualTo(new[] { "four", "five", "six" }));
         }
+
+        [Test]
+        public void ThenItHandlesEmptyStringInput() {
+            var grid = "";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ThenItThrowsOnNullGridInput() {
+            string grid = null;
+            var separator = ",";
+
+            Assert.Throws<ArgumentNullException>(() => TwoDArrayConverter.ConvertTo2DArray(grid, separator));
+        }
+
+        [Test]
+        public void ThenItThrowsOnNullSeparatorInput() {
+            var grid = "1,2,3\n4,5,6";
+            string separator = null;
+
+            Assert.Throws<ArgumentNullException>(() => TwoDArrayConverter.ConvertTo2DArray(grid, separator));
+        }
+
+        [Test]
+        public void ThenItThrowsOnNullGridRowsArrayInput() {
+            string[] gridRows = null;
+            var separator = ",";
+
+            Assert.Throws<ArgumentNullException>(() => TwoDArrayConverter.ConvertTo2DArray(gridRows, separator));
+        }
+
+        [Test]
+        public void ThenItHandlesSeparatorThatDoesNotExistInInput() {
+            var grid = "1,2,3\n4,5,6";
+            var separator = "|";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "1,2,3" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "4,5,6" }));
+        }
+
+        [Test]
+        public void ThenItHandlesEmptySeparatorString() {
+            var grid = "abc\ndef";
+            var separator = "";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "abc" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "def" }));
+        }
+
+        [Test]
+        public void ThenItHandlesGridWithOnlyNewlines() {
+            var grid = "\n\n\n";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ThenItHandlesExcessiveLeadingNewlines() {
+            var grid = "\n\n\n1,2,3\n4,5,6";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "1", "2", "3" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "4", "5", "6" }));
+        }
+
+        [Test]
+        public void ThenItHandlesExcessiveTrailingNewlines() {
+            var grid = "1,2,3\n4,5,6\n\n\n";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "1", "2", "3" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "4", "5", "6" }));
+        }
+
+        [Test]
+        public void ThenItHandlesExcessiveLeadingAndTrailingNewlines() {
+            var grid = "\n\n1,2,3\n4,5,6\n\n";
+            var separator = ",";
+
+            var result = TwoDArrayConverter.ConvertTo2DArray(grid, separator);
+
+            Assert.That(result.Length, Is.EqualTo(2));
+            Assert.That(result[0], Is.EqualTo(new[] { "1", "2", "3" }));
+            Assert.That(result[1], Is.EqualTo(new[] { "4", "5", "6" }));
+        }
     }
 }

--- a/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
+++ b/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
@@ -1,10 +1,6 @@
 ﻿namespace SharedUtilities.Test.UsingTheTwoDArrayConverter {
     public class WhenAStringIsPassedInWithASeparator {
 
-        [SetUp]
-        public void Setup() {
-        }
-
         [Test]
         public void ThenItIsConvertedToA2DArray() {
             var grid = "1,2,3\n4,5,6\n7,8,9";

--- a/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
+++ b/AdventOfCode2025/SharedUtilities.Test/UsingTheTwoDArrayConverter/WhenAStringIsPassedInWithASeparator.cs
@@ -1,0 +1,15 @@
+﻿using SharedUtilities;
+
+namespace SharedUtilities.Test.UsingTheTwoDArrayConverter {
+    public class WhenAStringIsPassedInWithASeparator {
+
+        [SetUp]
+        public void Setup() {
+        }
+
+        [Test]
+        public void ThenItIsConvertedToA2DArray() {
+            Assert.Pass();
+        }
+    }
+}

--- a/AdventOfCode2025/SharedUtilities/SharedUtilities.csproj
+++ b/AdventOfCode2025/SharedUtilities/SharedUtilities.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/AdventOfCode2025/SharedUtilities/TwoDArrayConverter.cs
+++ b/AdventOfCode2025/SharedUtilities/TwoDArrayConverter.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SharedUtilities {
     public static class TwoDArrayConverter {
         /// <summary>
@@ -6,6 +8,10 @@ namespace SharedUtilities {
         /// <param name="grid">The grid as a single string with rows separated by the newline character ('\n').</param>
         /// <returns>A jagged char[][] where each element is the characters of the corresponding input row (trimmed of surrounding whitespace).</returns>
         public static char[][] ConvertTo2DArray(string grid) {
+            if (grid == null) {
+                throw new ArgumentNullException(nameof(grid), "Input grid string cannot be null.");
+            }
+
             var rows = grid.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
             return ConvertTo2DArray(rows);
         }
@@ -16,6 +22,10 @@ namespace SharedUtilities {
         /// <param name="gridRows">Array of strings where each element represents a row; leading and trailing whitespace is removed from each row before conversion.</param>
         /// <returns>A jagged char[][] where each element is the sequence of characters of the corresponding trimmed input row.</returns>
         public static char[][] ConvertTo2DArray(string[] gridRows) {
+            if (gridRows == null) {
+                throw new ArgumentNullException(nameof(gridRows), "Input grid rows cannot be null.");
+            }
+
             var twoDArray = new char[gridRows.Length][];
 
             for (var currentRowIndex = 0; currentRowIndex < gridRows.Length; currentRowIndex++) {
@@ -26,12 +36,40 @@ namespace SharedUtilities {
             return twoDArray;
         }
 
+        /// <summary>
+        /// Converts a newline-delimited string representation of a grid into a jagged 2D string array.
+        /// </summary>
+        /// <param name="grid">The grid as a single string with rows separated by newline characters ('\r' or '\n').</param>
+        /// <param name="columnSeparator">The string used to separate columns within each row.</param>
+        /// <returns>A jagged string[][] where each element is an array of column values from the corresponding input row (trimmed of surrounding whitespace).</returns>
         public static string[][] ConvertTo2DArray(string grid, string columnSeparator) { 
+            if (grid == null) {
+                throw new ArgumentNullException(nameof(grid), "Input grid string cannot be null.");
+            }
+
+            if (columnSeparator == null) {
+                throw new ArgumentNullException(nameof(columnSeparator), "Column separator cannot be null.");
+            }
+
             var rows = grid.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
             return ConvertTo2DArray(rows, columnSeparator);
         }
 
-        public static string[][] ConvertTo2DArray(string[] gridRows, string columnSeparator) { 
+        /// <summary>
+        /// Converts an array of row strings into a jagged two-dimensional string array.
+        /// </summary>
+        /// <param name="gridRows">Array of strings where each element represents a row; leading and trailing whitespace is removed from each row before conversion.</param>
+        /// <param name="columnSeparator">The string used to separate columns within each row.</param>
+        /// <returns>A jagged string[][] where each element is an array of column values split by the separator from the corresponding trimmed input row.</returns>
+        public static string[][] ConvertTo2DArray(string[] gridRows, string columnSeparator) {
+            if (gridRows == null) {
+                throw new ArgumentNullException(nameof(gridRows), "Input grid string cannot be null.");
+            }
+
+            if (columnSeparator == null) {
+                throw new ArgumentNullException(nameof(columnSeparator), "Column separator cannot be null.");
+            }
+
             var twoDArray = new string[gridRows.Length][];
 
             for (var currentRowIndex = 0; currentRowIndex < gridRows.Length; currentRowIndex++) {

--- a/AdventOfCode2025/SharedUtilities/TwoDArrayConverter.cs
+++ b/AdventOfCode2025/SharedUtilities/TwoDArrayConverter.cs
@@ -1,5 +1,5 @@
-namespace Day4 {
-    internal static class TwoDArrayConverter {
+namespace SharedUtilities {
+    public static class TwoDArrayConverter {
         /// <summary>
         /// Converts a newline-delimited string representation of a grid into a jagged 2D char array.
         /// </summary>
@@ -21,6 +21,22 @@ namespace Day4 {
             for (var currentRowIndex = 0; currentRowIndex < gridRows.Length; currentRowIndex++) {
                 var currentRow = gridRows[currentRowIndex];
                 twoDArray[currentRowIndex] = currentRow.Trim().ToCharArray();
+            }
+
+            return twoDArray;
+        }
+
+        public static string[][] ConvertTo2DArray(string grid, string columnSeparator) { 
+            var rows = grid.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+            return ConvertTo2DArray(rows, columnSeparator);
+        }
+
+        public static string[][] ConvertTo2DArray(string[] gridRows, string columnSeparator) { 
+            var twoDArray = new string[gridRows.Length][];
+
+            for (var currentRowIndex = 0; currentRowIndex < gridRows.Length; currentRowIndex++) {
+                var currentRow = gridRows[currentRowIndex];
+                twoDArray[currentRowIndex] = currentRow.Trim().Split(columnSeparator, StringSplitOptions.RemoveEmptyEntries);
             }
 
             return twoDArray;

--- a/AdventOfCode2025/SharedUtilities/TwoDArrayConverter.cs
+++ b/AdventOfCode2025/SharedUtilities/TwoDArrayConverter.cs
@@ -68,7 +68,7 @@ namespace SharedUtilities {
         /// <returns>A jagged string[][] where each element is an array of column values split by the separator from the corresponding trimmed input row.</returns>
         public static string[][] ConvertTo2DArray(string[] gridRows, string columnSeparator) {
             if (gridRows == null) {
-                throw new ArgumentNullException(nameof(gridRows), "Input grid string cannot be null.");
+                throw new ArgumentNullException(nameof(gridRows), "Input grid rows cannot be null.");
             }
 
             if (columnSeparator == null) {

--- a/AdventOfCode2025/SharedUtilities/TwoDArrayConverter.cs
+++ b/AdventOfCode2025/SharedUtilities/TwoDArrayConverter.cs
@@ -30,6 +30,11 @@ namespace SharedUtilities {
 
             for (var currentRowIndex = 0; currentRowIndex < gridRows.Length; currentRowIndex++) {
                 var currentRow = gridRows[currentRowIndex];
+
+                if (currentRow == null) {
+                    throw new ArgumentException($"Element at index {currentRowIndex} in gridRows cannot be null.", nameof(gridRows));
+                }
+                
                 twoDArray[currentRowIndex] = currentRow.Trim().ToCharArray();
             }
 
@@ -74,6 +79,11 @@ namespace SharedUtilities {
 
             for (var currentRowIndex = 0; currentRowIndex < gridRows.Length; currentRowIndex++) {
                 var currentRow = gridRows[currentRowIndex];
+                
+                if (currentRow == null) {
+                    throw new ArgumentException($"Element at index {currentRowIndex} in gridRows cannot be null.", nameof(gridRows));
+                }
+
                 twoDArray[currentRowIndex] = currentRow.Trim().Split(columnSeparator, StringSplitOptions.RemoveEmptyEntries);
             }
 


### PR DESCRIPTION
- Put puzzle projects into their own folder
- Add new SharedUtilities folder with a class library and test project inside, ready for when the `TwoDArrayConverter` is needed for day 6.
- Add new methods in `TwoDArrayConverter`
  - As well as handling splitting by character as per before, you can now use it to separate cells with a given separator, e.g. `,` 
  - Tests added for `TwoDArrayConverter`. Generated by GitHub CoPilot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared utilities library and multiple puzzle solution projects to the solution.
  * Grid conversion utility now supports both character and string grids and configurable column separators.

* **Tests**
  * Extensive unit tests added for the grid converter covering separators, trimming, CRLF, uneven rows, empty/null inputs and many edge cases.

* **Chores**
  * Solution and project metadata updated to include new projects; test tooling versions upgraded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->